### PR TITLE
Fixed unwanted "cd .." if "cd target" fails because target doesn't exist

### DIFF
--- a/Back-End/server-side/start.bat
+++ b/Back-End/server-side/start.bat
@@ -1,4 +1,2 @@
-cd target
-del *.jar
-cd ..
+del target\*.jar
 mvn package && java -jar target/wrseg-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Aveam probleme ca imi lipsea directorul Back-End/server-side/target si a trebuit sa il creez manual. Imi facea "cd .." si apela mvn in Back-End in loc de Back-End/server-side.